### PR TITLE
Filled the empty space under the office section

### DIFF
--- a/CSS/contact.css
+++ b/CSS/contact.css
@@ -56,6 +56,7 @@ body {
 
 .contact-details p {
   margin: 0;
+  color:black
 }
 
 form {


### PR DESCRIPTION
I thought to add a FAQ's section in the empty space of contact us section under the office tag but after going through the code i saw the address was written but it was not visible in the website so i changed the color of the address text now address is visble and no empty space is there 
you can the preview of contact uspage now address is visble:
<img width="1440" alt="Screenshot 2024-10-18 at 11 38 29 PM" src="https://github.com/user-attachments/assets/0f85ea02-517b-4898-a9ff-873f17d260a4">

issue tag: #64 