### PR TITLE
Fix: Header Spacing and Center Footer Copyright (#124)

### DIFF
--- a/CSS/footer.css
+++ b/CSS/footer.css
@@ -206,6 +206,13 @@ ul {
 
 .copyright-area {
   padding: 25px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  text-align: center;
+  margin: 0 auto;
+  margin-left: 350px;
 }
 
 .copyright-text p {

--- a/style.css
+++ b/style.css
@@ -70,12 +70,16 @@ body {
 .logo {
   margin-left: 3rem;
   height: 100px;
+  height: 80px;
+  width: auto;
+  margin-top: -10px;
 }
 .contact-info {
   display: flex;
   align-items: center;
   height: 49px;
   gap: 20px;
+  margin-top: -5px;
 }
 .button-contact {
   padding: 0.7rem;
@@ -95,7 +99,7 @@ nav {
   position: relative;
   justify-content: space-between;
   align-items: flex-start;
-  margin-top: 0.5%;
+  margin-top: 50px;
   height: fit-content;
 }
 nav li {
@@ -138,6 +142,7 @@ nav li a:hover::after {
   /* margin-left: 13rem; */
   /* justify-content: end; */
   /* width: min-content; */
+  padding-top: 90px;
 }
 aside {
   display: flex;


### PR DESCRIPTION
This pull request addresses the following issues as outlined in #124:

Header Spacing: Adjusted inconsistent spacing at the top of the header to ensure a cleaner and more balanced look

Centered Footer Copyright: Updated the footer layout to center-align the copyright text,

Screenshots:

Header Spacing Fixed:
![image](https://github.com/user-attachments/assets/9e99352f-6364-4a9d-9e2b-a8331d2c7ee4)


Copyright Info Centered:
![image](https://github.com/user-attachments/assets/e62c4795-c4d0-4b7b-b8bb-49ff6daf5818)

Issue Reference: Fixes #124
